### PR TITLE
bottle :unneeded is deprecated

### DIFF
--- a/skuld.rb
+++ b/skuld.rb
@@ -6,8 +6,7 @@ class Skuld < Formula
   desc "CLI tool for AWS MFA credentials"
   homepage "https://github.com/DEEP-IMPACT-AG/skuld"
   version "0.7.5"
-  bottle :unneeded
-
+  
   if OS.mac?
     url "https://github.com/DEEP-IMPACT-AG/skuld/releases/download/v0.7.5/skuld_0.7.5_Darwin_x86_64.tar.gz"
     sha256 "f2e8adbd1bea2316413742c37d562fd7bd3aa389bc209d79c0572ee444b7a415"


### PR DESCRIPTION
This is a workaround.

A better way would be to update the https://github.com/DEEP-IMPACT-AG/go-snapcraft-builder docker image to use a newer version of the goreleaser (and of go maybe). And then rebuild a version of https://github.com/DEEP-IMPACT-AG/skuld with the new gorelease docker image.